### PR TITLE
Fix double Wait call on shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,12 +79,7 @@ func main() {
 		}
 		cmdMutex.Unlock()
 
-		// Đợi main.exe thoát
-		cmdMutex.Lock()
-		if currentCmd != nil {
-			currentCmd.Wait() // Đợi main.exe tự thoát
-		}
-		cmdMutex.Unlock()
+		// Việc đợi tiến trình kết thúc đã được thực hiện ở vòng lặp chính
 
 		close(exitChan)
 	}()


### PR DESCRIPTION
## Summary
- avoid waiting twice for child process when handling SIGINT/SIGTERM

## Testing
- `go vet ./...`
- `go build`

------
https://chatgpt.com/codex/tasks/task_e_688327beeb54832dac692ae2b3e46866